### PR TITLE
Create root personal tracker ms project

### DIFF
--- a/personal-tracker-ms/pom.xml
+++ b/personal-tracker-ms/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <name>Personal Tracker Microservices</name>
-    <description>Root project for Personal Tracker Microservices Application</description>
+    <description>Root project for Personal Tracker microservices application</description>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
@@ -62,15 +62,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring-boot.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
-                    <configuration>
-                        <source>21</source>
-                        <target>21</target>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Initial setup of the root Maven project for `personal-tracker-ms` microservices application.

This PR establishes the foundational Maven parent project, configuring dependency management for Spring Boot and Spring Cloud, defining the application's modules, and setting Java 21 as the target. The explicit `maven-compiler-plugin` configuration was removed as the source and target versions are already defined globally via properties, making the plugin configuration redundant.

---
<a href="https://cursor.com/background-agent?bcId=bc-25f5ac21-d84d-4fe7-8930-662d357fafe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25f5ac21-d84d-4fe7-8930-662d357fafe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

